### PR TITLE
/pool_metadata - Add optional _pool_bech32_id argument

### DIFF
--- a/postman/collection/Koios.postman_collection.json
+++ b/postman/collection/Koios.postman_collection.json
@@ -91,7 +91,7 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{schema}}://{{koios_host}}.{{koios_domain}}/{{path}}/v0/epoch_info?_epoch_no={{epoch_no}}",
+									"raw": "{{schema}}://{{koios_host}}.{{koios_domain}}/{{path}}/v0/epoch_info",
 									"protocol": "{{schema}}",
 									"host": [
 										"{{koios_host}}",
@@ -105,7 +105,8 @@
 									"query": [
 										{
 											"key": "_epoch_no",
-											"value": "{{epoch_no}}"
+											"value": "{{epoch_no}}",
+											"disabled": true
 										}
 									]
 								}
@@ -118,7 +119,7 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{schema}}://{{koios_host}}.{{koios_domain}}/{{path}}/v0/epoch_params?_epoch_no={{epoch_no}}",
+									"raw": "{{schema}}://{{koios_host}}.{{koios_domain}}/{{path}}/v0/epoch_params",
 									"protocol": "{{schema}}",
 									"host": [
 										"{{koios_host}}",
@@ -132,7 +133,8 @@
 									"query": [
 										{
 											"key": "_epoch_no",
-											"value": "{{epoch_no}}"
+											"value": "{{epoch_no}}",
+											"disabled": true
 										}
 									]
 								}
@@ -160,6 +162,18 @@
 										"{{path}}",
 										"v0",
 										"blocks"
+									],
+									"query": [
+										{
+											"key": "limit",
+											"value": "2",
+											"disabled": true
+										},
+										{
+											"key": "order",
+											"value": "block_height.desc",
+											"disabled": true
+										}
 									]
 								}
 							},
@@ -333,6 +347,13 @@
 										"{{path}}",
 										"v0",
 										"tx_metalabels"
+									],
+									"query": [
+										{
+											"key": "order",
+											"value": "metalabel.asc",
+											"disabled": true
+										}
 									]
 								}
 							},
@@ -455,6 +476,13 @@
 										"{{path}}",
 										"v0",
 										"address_txs"
+									],
+									"query": [
+										{
+											"key": "order",
+											"value": "block_height.desc",
+											"disabled": true
+										}
 									]
 								}
 							},
@@ -1124,8 +1152,17 @@
 						{
 							"name": "Pool Metadata",
 							"request": {
-								"method": "GET",
+								"method": "POST",
 								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
 								"url": {
 									"raw": "{{schema}}://{{koios_host}}.{{koios_domain}}/{{path}}/v0/pool_metadata",
 									"protocol": "{{schema}}",

--- a/src/main/java/rest/koios/client/backend/api/pool/PoolService.java
+++ b/src/main/java/rest/koios/client/backend/api/pool/PoolService.java
@@ -178,4 +178,18 @@ public interface PoolService {
      * @throws ApiException if an error occurs while attempting to invoke the API
      */
     Result<List<PoolMetadata>> getPoolMetadata(Options options) throws ApiException;
+
+    /**
+     * Pool Metadata by Pool Ids with Filtering, Pagination, Ordering Options
+     * Metadata(on &amp; off-chain) for all currently registered/retiring (not retired) pools
+     * <p><b>200</b> - Success!
+     * <p><b>401</b> - The selected server has restricted the endpoint to be only usable via authentication. The authentication supplied was not authorized to access the endpoint
+     * <p><b>404</b> - The server does not recognise the combination of endpoint and parameters provided
+     *
+     * @param poolIds Pool Bech32 Ids List (optional)
+     * @param options Filtering and Pagination options (optional)
+     * @return Result of Type List of {@link PoolMetadata}
+     * @throws ApiException if an error occurs while attempting to invoke the API
+     */
+    Result<List<PoolMetadata>> getPoolMetadata(List<String> poolIds, Options options) throws ApiException;
 }

--- a/src/main/java/rest/koios/client/backend/api/pool/api/PoolApi.java
+++ b/src/main/java/rest/koios/client/backend/api/pool/api/PoolApi.java
@@ -45,6 +45,6 @@ public interface PoolApi {
     @GET("pool_relays")
     Call<List<PoolRelay>> getPoolRelays(@QueryMap Map<String, String> paramsMap);
 
-    @GET("pool_metadata")
-    Call<List<PoolMetadata>> getPoolMetadata(@QueryMap Map<String, String> paramsMap);
+    @POST("pool_metadata")
+    Call<List<PoolMetadata>> getPoolMetadata(@Body Map<String, Object> requestBody, @QueryMap Map<String, String> paramsMap);
 }

--- a/src/main/java/rest/koios/client/backend/api/pool/impl/PoolServiceImpl.java
+++ b/src/main/java/rest/koios/client/backend/api/pool/impl/PoolServiceImpl.java
@@ -11,6 +11,7 @@ import retrofit2.Call;
 import retrofit2.Response;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -168,7 +169,15 @@ public class PoolServiceImpl extends BaseService implements PoolService {
 
     @Override
     public Result<List<PoolMetadata>> getPoolMetadata(Options options) throws ApiException {
-        Call<List<PoolMetadata>> call = poolApi.getPoolMetadata(optionsToParamMap(options));
+        return getPoolMetadata(Collections.emptyList(), options);
+    }
+
+    @Override
+    public Result<List<PoolMetadata>> getPoolMetadata(List<String> poolIds, Options options) throws ApiException {
+        for (String poolId : poolIds) {
+            validateBech32(poolId);
+        }
+        Call<List<PoolMetadata>> call = poolApi.getPoolMetadata(buildBody(poolIds), optionsToParamMap(options));
         try {
             Response<List<PoolMetadata>> response = (Response) execute(call);
             return processResponse(response);
@@ -179,7 +188,9 @@ public class PoolServiceImpl extends BaseService implements PoolService {
 
     private Map<String, Object> buildBody(List<String> poolIds) {
         Map<String, Object> bodyMap = new HashMap<>();
-        bodyMap.put("_pool_bech32_ids", poolIds);
+        if (!poolIds.isEmpty()) {
+            bodyMap.put("_pool_bech32_ids", poolIds);
+        }
         return bodyMap;
     }
 }


### PR DESCRIPTION
Query (input) changes on existing endpoints:
- /pool_metadata - Add optional _pool_bech32_id argument to allow passing bulk pool ids as input (#1389 (https://github.com/cardano-community/guild-operators/pull/1389)) [ API Update here (https://github.com/cardano-community/koios-artifacts/pull/20) ]