### PR TITLE
Add  coinsPerUtxoSize field to EpochParams

### DIFF
--- a/src/main/java/rest/koios/client/backend/api/block/model/Block.java
+++ b/src/main/java/rest/koios/client/backend/api/block/model/Block.java
@@ -1,5 +1,6 @@
 package rest.koios.client.backend.api.block.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.*;
@@ -12,6 +13,7 @@ import lombok.*;
 @ToString
 @NoArgsConstructor
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Block {
 
     /**

--- a/src/main/java/rest/koios/client/backend/api/block/model/BlockInfo.java
+++ b/src/main/java/rest/koios/client/backend/api/block/model/BlockInfo.java
@@ -1,5 +1,6 @@
 package rest.koios.client.backend.api.block.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.*;
@@ -12,6 +13,7 @@ import lombok.*;
 @ToString
 @NoArgsConstructor
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class BlockInfo {
 
     /**

--- a/src/main/java/rest/koios/client/backend/api/epoch/model/EpochInfo.java
+++ b/src/main/java/rest/koios/client/backend/api/epoch/model/EpochInfo.java
@@ -1,5 +1,6 @@
 package rest.koios.client.backend.api.epoch.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.*;
@@ -13,6 +14,7 @@ import lombok.*;
 @NoArgsConstructor
 @EqualsAndHashCode
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class EpochInfo {
 
     /**

--- a/src/main/java/rest/koios/client/backend/api/epoch/model/EpochParams.java
+++ b/src/main/java/rest/koios/client/backend/api/epoch/model/EpochParams.java
@@ -1,5 +1,6 @@
 package rest.koios.client.backend.api.epoch.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.*;
@@ -14,6 +15,7 @@ import java.math.BigDecimal;
 @ToString
 @NoArgsConstructor
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class EpochParams {
 
     /**
@@ -173,6 +175,12 @@ public class EpochParams {
 
     /**
      * The cost per UTxO word
+     * @deprecated
      */
     private Integer coinsPerUtxoWord = null;
+
+    /**
+     * The cost per UTxO byte
+     */
+    private Integer coinsPerUtxoSize = null;
 }


### PR DESCRIPTION
## Description
1.Babbage era's protocol parameter has a new field "coinsPerUtxoSize". This PR adds this new field to EpochParams class. 
2. Add @JsonIgnoreProperties(ignoreUnknown = true) to avoid unknown properties error due to new properties in Block, BlockInfo and Epoch Info


## Where should the reviewer start?
<!--- Describe where reviewer should start testing -->

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->

## Which issue it fixes?
<!--- Link to issue: Closes #issue-number -->

## How has this been tested?
With existing tests
