### PR TITLE
Add options in asset policy info API

### DIFF
--- a/src/main/java/rest/koios/client/backend/api/asset/AssetService.java
+++ b/src/main/java/rest/koios/client/backend/api/asset/AssetService.java
@@ -64,10 +64,11 @@ public interface AssetService {
      * <p><b>404</b> - The server does not recognise the combination of endpoint and parameters provided
      *
      * @param assetPolicy Asset Policy ID in hexadecimal format (hex) (required)
+     * @param options     Filtering and Pagination options (optional)
      * @return Result of Type List of {@link PolicyAsset}
      * @throws ApiException if an error occurs while attempting to invoke the API
      */
-    Result<List<PolicyAsset>> getAssetPolicyInformation(String assetPolicy) throws ApiException;
+    Result<List<PolicyAsset>> getAssetPolicyInformation(String assetPolicy, Options options) throws ApiException;
 
     /**
      * Asset Information

--- a/src/main/java/rest/koios/client/backend/api/asset/api/AssetApi.java
+++ b/src/main/java/rest/koios/client/backend/api/asset/api/AssetApi.java
@@ -28,7 +28,7 @@ public interface AssetApi {
     Call<List<AssetHistory>> getAssetHistory(@Query("_asset_policy") String assetPolicy, @Query("_asset_name") String assetName, @QueryMap Map<String, String> paramsMap);
 
     @GET("asset_policy_info")
-    Call<List<PolicyAsset>> getAssetPolicyInformation(@Query("_asset_policy") String assetPolicy);
+    Call<List<PolicyAsset>> getAssetPolicyInformation(@Query("_asset_policy") String assetPolicy, @QueryMap Map<String, String> paramsMap);
 
     @GET("asset_summary")
     Call<List<AssetSummary>> getAssetSummary(@Query("_asset_policy") String assetPolicy, @Query("_asset_name") String assetName);

--- a/src/main/java/rest/koios/client/backend/api/asset/impl/AssetServiceImpl.java
+++ b/src/main/java/rest/koios/client/backend/api/asset/impl/AssetServiceImpl.java
@@ -82,9 +82,9 @@ public class AssetServiceImpl extends BaseService implements AssetService {
     }
 
     @Override
-    public Result<List<PolicyAsset>> getAssetPolicyInformation(String assetPolicy) throws ApiException {
+    public Result<List<PolicyAsset>> getAssetPolicyInformation(String assetPolicy, Options options) throws ApiException {
         validateHexFormat(assetPolicy);
-        Call<List<PolicyAsset>> call = assetApi.getAssetPolicyInformation(assetPolicy);
+        Call<List<PolicyAsset>> call = assetApi.getAssetPolicyInformation(assetPolicy, optionsToParamMap(options));
         try {
             Response<List<PolicyAsset>> response = (Response) execute(call);
             return processResponse(response);

--- a/src/test/java/rest/koios/client/backend/api/asset/AssetServiceMainnetIntegrationTest.java
+++ b/src/test/java/rest/koios/client/backend/api/asset/AssetServiceMainnetIntegrationTest.java
@@ -107,7 +107,7 @@ class AssetServiceMainnetIntegrationTest {
     @Test
     void getAssetPolicyInformationTest() throws ApiException {
         String assetPolicy = "14696a4676909f4e3cb1f2e60e2e08e5abed70caf5c02699be971139";
-        Result<List<PolicyAsset>> assetPolicyInfoResult = assetService.getAssetPolicyInformation(assetPolicy);
+        Result<List<PolicyAsset>> assetPolicyInfoResult = assetService.getAssetPolicyInformation(assetPolicy, Options.EMPTY);
         Assertions.assertTrue(assetPolicyInfoResult.isSuccessful());
         Assertions.assertNotNull(assetPolicyInfoResult.getValue());
         log.info(assetPolicyInfoResult.getValue().toString());
@@ -116,7 +116,7 @@ class AssetServiceMainnetIntegrationTest {
     @Test
     void getAssetPolicyInformationBadRequestTest() {
         String assetPolicy = "test";
-        ApiException exception = assertThrows(ApiException.class, () -> assetService.getAssetPolicyInformation(assetPolicy));
+        ApiException exception = assertThrows(ApiException.class, () -> assetService.getAssetPolicyInformation(assetPolicy, Options.EMPTY));
         assertInstanceOf(ApiException.class, exception);
     }
 

--- a/src/test/java/rest/koios/client/backend/api/asset/AssetServicePreprodIntegrationTest.java
+++ b/src/test/java/rest/koios/client/backend/api/asset/AssetServicePreprodIntegrationTest.java
@@ -111,7 +111,7 @@ class AssetServicePreprodIntegrationTest {
     @Test
     void getAssetPolicyInformationTest() throws ApiException {
         String assetPolicy = "80de4ee0ffde8ba05726707f2adba0e65963eff5aaba164af358e71b";
-        Result<List<PolicyAsset>> assetPolicyInfoResult = assetService.getAssetPolicyInformation(assetPolicy);
+        Result<List<PolicyAsset>> assetPolicyInfoResult = assetService.getAssetPolicyInformation(assetPolicy, Options.EMPTY);
         Assertions.assertTrue(assetPolicyInfoResult.isSuccessful());
         Assertions.assertNotNull(assetPolicyInfoResult.getValue());
         log.info(assetPolicyInfoResult.getValue().toString());
@@ -120,7 +120,7 @@ class AssetServicePreprodIntegrationTest {
     @Test
     void getAssetPolicyInformationBadRequestTest() {
         String assetPolicy = "test";
-        ApiException exception = assertThrows(ApiException.class, () -> assetService.getAssetPolicyInformation(assetPolicy));
+        ApiException exception = assertThrows(ApiException.class, () -> assetService.getAssetPolicyInformation(assetPolicy, Options.EMPTY));
         assertInstanceOf(ApiException.class, exception);
     }
 

--- a/src/test/java/rest/koios/client/backend/api/asset/AssetServicePreviewIntegrationTest.java
+++ b/src/test/java/rest/koios/client/backend/api/asset/AssetServicePreviewIntegrationTest.java
@@ -111,7 +111,7 @@ class AssetServicePreviewIntegrationTest {
     @Test
     void getAssetPolicyInformationTest() throws ApiException {
         String assetPolicy = "9a50f458ebffb4c3f9d6f9f3d45426b2de6cf2512254f4bfa3d8f410";
-        Result<List<PolicyAsset>> assetPolicyInfoResult = assetService.getAssetPolicyInformation(assetPolicy);
+        Result<List<PolicyAsset>> assetPolicyInfoResult = assetService.getAssetPolicyInformation(assetPolicy, Options.EMPTY);
         Assertions.assertTrue(assetPolicyInfoResult.isSuccessful());
         Assertions.assertNotNull(assetPolicyInfoResult.getValue());
         log.info(assetPolicyInfoResult.getValue().toString());
@@ -120,7 +120,7 @@ class AssetServicePreviewIntegrationTest {
     @Test
     void getAssetPolicyInformationBadRequestTest() {
         String assetPolicy = "test";
-        ApiException exception = assertThrows(ApiException.class, () -> assetService.getAssetPolicyInformation(assetPolicy));
+        ApiException exception = assertThrows(ApiException.class, () -> assetService.getAssetPolicyInformation(assetPolicy, Options.EMPTY));
         assertInstanceOf(ApiException.class, exception);
     }
 


### PR DESCRIPTION
## Description
Asset Policy Information API requires paging.

## Where should the reviewer start?
Only options have been added.

## Motivation and context
It is required to look up more than a thousand assets.

## Which issue it fixes?

## How has this been tested?
